### PR TITLE
Disable mining fatigue

### DIFF
--- a/src/main/java/com/untamedears/humbug/Humbug.java
+++ b/src/main/java/com/untamedears/humbug/Humbug.java
@@ -2606,6 +2606,16 @@ public class Humbug extends JavaPlugin implements Listener {
     }
   }
   
+  @BahHumbug(opt="disable_mining_fatigue", def="true")
+  public void onInteractMiningSomething(PlayerInteractEvent event)
+  {
+    if (!config_.get("disable_mining_fatigue").getBool()) {
+        return;
+    }
+    Player p = event.getPlayer();
+    p.removePotionEffect(PotionEffectType.SLOW_DIGGING);
+  }
+  
   // ================================================
   // Enforce good sign data length
 


### PR DESCRIPTION
@TealNerd wanted to do this a year ago, but was lazy. Please merge and put online, thanks @ribagi 

Also about the code: There's no event for applying the buff, so we have to remove it in this semi-hacky way. It'll work fine. You could probably use ProtocolLib to catch the outgoing packet with mining fatigue, but that's too much effort for me.